### PR TITLE
Refresh install_linuxsampler.sh

### DIFF
--- a/scripts/recipes/pending/install_linuxsampler.sh
+++ b/scripts/recipes/pending/install_linuxsampler.sh
@@ -1,5 +1,7 @@
 # linuxsampler
+set -ex
 cd $ZYNTHIAN_SW_DIR
+sudo apt remove -y linuxsampler libgig6 liblinuxsampler
 sudo apt-get install -y subversion libtool flex bison
 svn co https://svn.linuxsampler.org/svn/libgig/trunk libgig
 cd libgig
@@ -36,13 +38,10 @@ autoconf
 cd src/scriptvm
 yacc -o parser parser.y
 cd ../..
-git clone https://github.com/coolder/rpi_linuxsampler_patch.git
-patch -p0 <rpi_linuxsampler_patch/atomic.h.diff 
-cd src/common/
-patch <../../rpi_linuxsampler_patch/RTMath.cpp.diff
-cd ../../
+git clone https://github.com/steveb/rpi_linuxsampler_patch.git
+patch -p1 <rpi_linuxsampler_patch/linuxsampler-arm.patch 
 make
 sudo make install
-sudo mv /usr/local/lib/lv2/linuxsampler.lv2 "${HOME}"/zynthian/zynthian-plugins/mod-lv2
+sudo mv /usr/local/lib/lv2/linuxsampler.lv2 ${ZYNTHIAN_PLUGINS_DIR}/mod-lv2
 make clean
 cd ..


### PR DESCRIPTION
This updates the script to install linuxsampler from source by doing:
- uninstalls packaged linuxsampler
- switches rpi_linuxsampler_patch to a refreshed patch which actually applies

The patch in [1] has been proposed to the linuxsampler-devel list, so hopefully
it will be applied.

[1] https://github.com/steveb/rpi_linuxsampler_patch