### PR TITLE
Optionally clean up apt cache directory during build (fixes #16)

### DIFF
--- a/scripts/setup_system_rbpi_minibian_jessie.sh
+++ b/scripts/setup_system_rbpi_minibian_jessie.sh
@@ -103,7 +103,7 @@ pip3 install JACK-Client
 
 # Clean
 apt-get -y autoremove # Remove unneeded packages
-if [[ "$ZYNTHAIN_SETUP_CLEANCACHE" = "TRUE" ]]; then # Clean apt cache (if instructed via zynthian_envars.sh)
+if [[ "$ZYNTHAIN_SETUP_APT_CLEAN" = "TRUE" ]]; then # Clean apt cache (if instructed via zynthian_envars.sh)
    apt-get clean
 fi
 

--- a/scripts/setup_system_rbpi_minibian_jessie.sh
+++ b/scripts/setup_system_rbpi_minibian_jessie.sh
@@ -102,7 +102,10 @@ pip3 install websocket-client
 pip3 install JACK-Client
 
 # Clean
-apt-get -y autoremove
+apt-get -y autoremove # Remove unneeded packages
+if [[ "$ZYNTHAIN_SETUP_CLEANCACHE" = "TRUE" ]]; then # Clean apt cache (if instructed via zynthian_envars.sh)
+   apt-get clean
+fi
 
 #************************************************
 #------------------------------------------------
@@ -113,7 +116,7 @@ apt-get -y autoremove
 mkdir $ZYNTHIAN_DIR
 mkdir $ZYNTHIAN_CONFIG_DIR
 
-# Zyncoder library
+# Zyncoder library 
 cd $ZYNTHIAN_DIR
 git clone https://github.com/zynthian/zyncoder.git
 mkdir zyncoder/build

--- a/scripts/zynthian_envars.sh
+++ b/scripts/zynthian_envars.sh
@@ -97,4 +97,4 @@ export CFLAGS_UNSAFE
 #echo "Hardware Model: ${model}"
 
 # Setup / Build Options
-export ZYNTHAIN_SETUP_CLEANCACHE="TRUE" # Set TRUE to clean /var/cache/apt during build, FALSE to leave alone
+export ZYNTHAIN_SETUP_CLEAN_CACHE="TRUE" # Set TRUE to clean /var/cache/apt during build, FALSE to leave alone

--- a/scripts/zynthian_envars.sh
+++ b/scripts/zynthian_envars.sh
@@ -95,3 +95,6 @@ export CXXFLAGS=${CFLAGS}
 export CFLAGS_UNSAFE
 #echo "Hardware Architecture: ${machine}"
 #echo "Hardware Model: ${model}"
+
+# Setup / Build Options
+export ZYNTHAIN_SETUP_CLEANCACHE="TRUE" # Set TRUE to clean /var/cache/apt during build, FALSE to leave alone

--- a/scripts/zynthian_envars.sh
+++ b/scripts/zynthian_envars.sh
@@ -97,4 +97,4 @@ export CFLAGS_UNSAFE
 #echo "Hardware Model: ${model}"
 
 # Setup / Build Options
-export ZYNTHAIN_SETUP_CLEAN_CACHE="TRUE" # Set TRUE to clean /var/cache/apt during build, FALSE to leave alone
+export ZYNTHAIN_SETUP_APT_CLEAN="TRUE" # Set TRUE to clean /var/cache/apt during build, FALSE to leave alone


### PR DESCRIPTION
This change adds the optional `$ZYNTHIAN_SETUP_CLEANCACHE` to `zynthian_envars.sh` in a new "Setup / Build Options" category, and - if set to `TRUE` - cleans the apt cache during the build process, saving ~630 MB on the image.