### PR TITLE
Fix apt-get install to right package name

### DIFF
--- a/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
+++ b/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
@@ -93,7 +93,7 @@ libavcodec56 libavformat56 libavutil54 libavresample2 python3-pyqt4 libxi-dev li
 
 # Python
 apt-get -y install python python-dev python-pip cython python-dbus 
-apt-get -y install python3 python3-dev python3-pip cython3 python3-cffi python3-tk python3-dbus python3-mpmath python3-PIL python3-pil.imagetk
+apt-get -y install python3 python3-dev python3-pip cython3 python3-cffi python3-tk python3-dbus python3-mpmath python3-pil python3-pil.imagetk
 pip3 install websocket-client
 pip3 install JACK-Client
 

--- a/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
+++ b/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
@@ -86,7 +86,7 @@ libasound2-dev dbus-x11 jackd2 libjack-jackd2-dev a2jmidid laditools \
 liblash-compat-dev libffi-dev fontconfig-config libfontconfig1-dev libxft-dev \
 libexpat-dev libglib2.0-dev libgettextpo-dev libglibmm-2.4-dev libeigen3-dev \
 libsndfile-dev libsamplerate-dev libarmadillo-dev libreadline-dev lv2-c++-tools python3-numpy-dev \
-libavcodec56 libavformat56 libavutil54 libavresample2 python3-pyqt4 libxi-dev libsqlite3-dev
+libavcodec57 libavformat57 libavutil55 libavresample3 python3-pyqt4 libxi-dev libsqlite3-dev
 #libjack-dev-session
 #non-ntk-dev
 #libgd2-xpm-dev


### PR DESCRIPTION
At the moment the build gives this error:

```
+ apt-get -y install python3 python3-dev python3-pip cython3 python3-cffi python3-tk python3-dbus python3-mpmath python3-PIL python3-pil.imagetk
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python3-PIL
```

All the packages in that line do not install, this fixes the line. All Debian packages are lower case.