### PR TITLE
Fix mv error

### DIFF
--- a/scripts/update_zynthian_sys.sh
+++ b/scripts/update_zynthian_sys.sh
@@ -174,8 +174,10 @@ fi
 if [ ! -d "$ZYNTHIAN_MY_DATA_DIR/presets/lv2" ]; then
 	# Create directory and link it
 	mkdir "$ZYNTHIAN_MY_DATA_DIR/presets/lv2"
-	mv /root/.lv2/* "$ZYNTHIAN_MY_DATA_DIR/presets/lv2"
-	rm -rf /root/.lv2
+	if [ -d /root/.lv2 ]; then
+	    mv /root/.lv2/* "$ZYNTHIAN_MY_DATA_DIR/presets/lv2"
+	    rm -rf /root/.lv2
+	fi
 	ln -s "$ZYNTHIAN_MY_DATA_DIR/presets/lv2" /root/.lv2
 	# Add to $LV2_PATH
 	sed -i -e "s/\/lv2\"/\/lv2\:\$ZYNTHIAN_MY_DATA_DIR\/presets\/lv2\"/g" $ZYNTHIAN_CONFIG_DIR/zynthian_envars.sh


### PR DESCRIPTION
Fixes the following error in the build for stretch:

```
bin/mv: cannot stat '/root/.lv2/*': No such file or directory
/usr/bin/touch: missing file operand
```

Full log:
http://gnethomelinux.com:8080/job/ZynthianOS/20/parsed_console/job/ZynthianOS/20/parsed_console/log_content.html#ERROR1

PRing so someone can review before I start pushing stuff.
