### PR TITLE
Run update after we update sources.list with debian multimedia

### DIFF
--- a/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
+++ b/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
@@ -63,6 +63,7 @@ fi
 
 # deb-multimedia repo
 echo "deb http://www.deb-multimedia.org stretch main" >> /etc/apt/sources.list
+apt-get update
 apt-get -y --force-yes install deb-multimedia-keyring
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5C808C2B65558117
 


### PR DESCRIPTION
I am getting:

```
E: Unable to locate package deb-multimedia-keyring
```

This makes sense, since you are adding the new repo to the source list, but not updating after that.