### PR TITLE
Allow any USB card to be accessed through DBus

### DIFF
--- a/etc/dbus-1/system-local.conf
+++ b/etc/dbus-1/system-local.conf
@@ -4,6 +4,8 @@
 
 <policy user="root">
      <allow own="org.freedesktop.ReserveDevice1.Audio0"/>
+     <allow own="org.freedesktop.ReserveDevice1.Audio1"/>
+     <allow own="org.freedesktop.ReserveDevice1.Audio2"/>
 </policy>
 
 </busconfig>


### PR DESCRIPTION
If more than one sound card is available to ALSA, but only one is to be used, we need to give DBus access to it.

Note: even with only 1 USB card, sometimes it even gets ALSA id 1 instead of 0. This happens if the system has previously booted with 2 cards (e.g. HifiBerry + USB) and on a subsequent boot the HifiBerry device overlay is removed.

By granting access to cards >0, stuff should mostly keep working in these varying scenarios. At least, it's the only change I had to made manually besides flipping the switch in the webconf :-)

In my personal Zynthian, I do have a built-in Hifiberry DAC+ Light, but I sometimes connect a more advanced USB sound card. The card that I feed to `jackd` hence sometimes has ID 0 and sometimes ID 1.