### PR TITLE
Expand replacement match for raspberry in hosts

### DIFF
--- a/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
+++ b/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
@@ -206,7 +206,7 @@ cp -a $ZYNTHIAN_DATA_DIR/mod-pedalboards/*.pedalboard $ZYNTHIAN_MY_DATA_DIR/mod-
 #Change Hostname
 if [ "$ZYNTHIAN_CHANGE_HOSTNAME" == "yes" ]; then
     echo "zynthian" > /etc/hostname
-    sed -i -e "s/raspbian/zynthian/" /etc/hosts
+    sed -i -e "s/raspb.*/zynthian/" /etc/hosts
 fi
 
 # Run configuration script


### PR DESCRIPTION
Will now match both raspberrypi and rasbian hostname in /etc/hosts to
correct issue where zynthian was not added as localhost.

https://github.com/zynthian/zynthian-sys/issues/99