### PR TITLE
New screen: WaveShare 4 inch IPS HDMI screen 800x480

### DIFF
--- a/custom/display/WaveShare 4 HDMI+GPIO/etc/X11/xorg.conf.d/99-calibration.conf
+++ b/custom/display/WaveShare 4 HDMI+GPIO/etc/X11/xorg.conf.d/99-calibration.conf
@@ -1,0 +1,5 @@
+Section "InputClass"
+	Identifier	"calibration"
+	MatchProduct	"ADS7846 Touchscreen"
+	Option	"TransformationMatrix" "0 -1 1 1 0 0 0 0 1"
+EndSection


### PR DESCRIPTION
Xorg calibration for this new screen, which I finally got the touch working by flipping the touch axes with a TransformationMatrix attribute

Screen info 4 inch IPS HDMI screen 800x480
https://www.waveshare.com/wiki/4inch_HDMI_LCD