### PR TITLE
Move /root/.lv2 to zynthian-my-data/presets/lv2

### DIFF
--- a/scripts/update_zynthian_data.sh
+++ b/scripts/update_zynthian_data.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 #******************************************************************************
 # ZYNTHIAN PROJECT: Update Zynthian Data
-# 
+#
 # + Update the Zynthian Data from repositories.
 # + Perform some extra fixes
-# 
+#
 # Copyright (C) 2015-2017 Fernando Moyano <jofemodo@zynthian.org>
 #
 #******************************************************************************
-# 
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of
@@ -49,6 +49,13 @@ fi
 cp -na $ZYNTHIAN_DATA_DIR/presets/mod-ui/pedalboards/*.pedalboard $ZYNTHIAN_MY_DATA_DIR/presets/mod-ui/pedalboards
 rm -f /root/.pedalboards
 ln -s $ZYNTHIAN_MY_DATA_DIR/presets/mod-ui/pedalboards /root/.pedalboards
+
+# Fix/Setup MOD-UI lv2 presets directory
+if [ ! -L /root/.lv2 ]; then
+	mv /root/.lv2/* $ZYNTHIAN_MY_DATA_DIR/presets/lv2
+	rm -rf /root/.lv2
+	ln -s $ZYNTHIAN_MY_DATA_DIR/presets/lv2 /root/.lv2
+fi
 
 # Fix/Setup setbfree user config directory
 if [ -d "$ZYNTHIAN_MY_DATA_DIR/setbfree" ]; then


### PR DESCRIPTION
MOD-UI stores user presets for individual plugins in /root/.lv2. This
change merges the contents of /root/.lv2 with
zynthian-my-data/presets/lv2 and then turns /root/.lv2 into a symlink.