### PR TITLE
Added install recipe for njconnect.

### DIFF
--- a/scripts/recipes/install_njconnect.sh
+++ b/scripts/recipes/install_njconnect.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# njconnect
+
+cd $ZYNTHIAN_PLUGINS_SRC_DIR
+svn checkout https://svn.code.sf.net/p/njconnect/code/trunk njconnect
+cd njconnect
+make -j 4
+make install
+make clean
+cd ..


### PR DESCRIPTION
Installation script for njconnect (see https://discourse.zynthian.org/t/qjackctl-not-displaying/2958/6)