### PR TITLE
Setting AudioInjector Ultra volume down

### DIFF
--- a/scripts/update_zynthian_sys.sh
+++ b/scripts/update_zynthian_sys.sh
@@ -350,13 +350,14 @@ fi
  
 if [ "$SOUNDCARD_NAME" == "AudioInjector Ultra" ]; then
 	echo "Configuring Alsa Mixer for AudioInjector Ultra ..."
-	amixer -c audioinjectorul cset name='DAC Switch' 1
+	amixer -c audioinjectorul cset name='DAC Switch' 0
 	amixer -c audioinjectorul cset name='DAC Volume' 240
 	amixer -c audioinjectorul cset name='DAC INV Switch' 0
 	amixer -c audioinjectorul cset name='DAC Soft Ramp Switch' 0
 	amixer -c audioinjectorul cset name='DAC Zero Cross Switch' 0
 	amixer -c audioinjectorul cset name='De-emp 44.1kHz Switch' 0
 	amixer -c audioinjectorul cset name='E to F Buffer Disable Switch' 0
+	amixer -c audioinjectorul cset name='DAC Switch' 1
 fi
 
 # Replace config vars in hostapd.conf

--- a/scripts/update_zynthian_sys.sh
+++ b/scripts/update_zynthian_sys.sh
@@ -352,6 +352,11 @@ if [ "$SOUNDCARD_NAME" == "AudioInjector Ultra" ]; then
 	echo "Configuring Alsa Mixer for AudioInjector Ultra ..."
 	amixer -c audioinjectorul cset name='DAC Switch' 1
 	amixer -c audioinjectorul cset name='DAC Volume' 240
+	amixer -c audioinjectorul cset name='DAC INV Switch' 0
+	amixer -c audioinjectorul cset name='DAC Soft Ramp Switch' 0
+	amixer -c audioinjectorul cset name='DAC Zero Cross Switch' 0
+	amixer -c audioinjectorul cset name='De-emp 44.1kHz Switch' 0
+	amixer -c audioinjectorul cset name='E to F Buffer Disable Switch' 0
 fi
 
 # Replace config vars in hostapd.conf

--- a/scripts/update_zynthian_sys.sh
+++ b/scripts/update_zynthian_sys.sh
@@ -347,6 +347,12 @@ if [ "$SOUNDCARD_NAME" == "AudioInjector" ]; then
 	amixer -c audioinjectorpi sset 'Output Mixer HiFi' unmute
 	amixer -c audioinjectorpi cset numid=10,iface=MIXER,name='Line Capture Switch' 1
 fi
+ 
+if [ "$SOUNDCARD_NAME" == "AudioInjector Ultra" ]; then
+	echo "Configuring Alsa Mixer for AudioInjector Ultra ..."
+	amixer -c audioinjectorul cset name='DAC Switch' 1
+	amixer -c audioinjectorul cset name='DAC Volume' 240
+fi
 
 # Replace config vars in hostapd.conf
 sed -i -e "s/#ZYNTHIAN_HOTSPOT_NAME#/$ZYNTHIAN_HOSTSPOT_NAME/g" /etc/hostapd/hostapd.conf


### PR DESCRIPTION
The AudioInjector Ultra is too loud per default
And ensuring, that it is enabled.