### PR TITLE
Changes for new name of the dexed plugin and using branch master inst…

### DIFF
--- a/scripts/recipes/install_dexed_dcoredump.sh
+++ b/scripts/recipes/install_dexed_dcoredump.sh
@@ -2,10 +2,8 @@
 
 
 cd $ZYNTHIAN_PLUGINS_SRC_DIR
-git clone https://github.com/dcoredump/dexed
-cd dexed
-git checkout native-lv2
-cd src
+git clone https://github.com/dcoredump/dexed.lv2
+cd dexed.lv2/src
 make -j 3
 make install
 cd ../..


### PR DESCRIPTION
Plugin renamed from "dexed" to "dexed.lv2" and now using "master" instead of branch "native-lv2".