### PR TITLE
Detect and build zyngui libs

### DIFF
--- a/scripts/update_zynthian_code.sh
+++ b/scripts/update_zynthian_code.sh
@@ -45,12 +45,7 @@ echo "Updating zynthian-ui ..."
 cd $ZYNTHIAN_UI_DIR
 git checkout .
 git pull | grep -q -v 'Already up.to.date.' && ui_changed=1
-if [ -d "jackpeak" ]; then
-	./jackpeak/build.sh
-fi
-if [ -d "zynseq" ]; then
-	./zynseq/build.sh
-fi
+find ./zynlibs -type f -name build.sh -exec {} \;
 
 echo "Updating zynthian-webconf ..."
 cd $ZYNTHIAN_DIR/zynthian-webconf

--- a/scripts/update_zynthian_code.sh
+++ b/scripts/update_zynthian_code.sh
@@ -45,7 +45,16 @@ echo "Updating zynthian-ui ..."
 cd $ZYNTHIAN_UI_DIR
 git checkout .
 git pull | grep -q -v 'Already up.to.date.' && ui_changed=1
-find ./zynlibs -type f -name build.sh -exec {} \;
+if [ -d "zynlibs" ]; then
+	find ./zynlibs -type f -name build.sh -exec {} \;
+else
+	if [ -d "jackpeak" ]; then
+		./jackpeak/build.sh
+	fi
+	if [ -d "zynseq" ]; then
+		./zynseq/build.sh
+	fi
+fi
 
 echo "Updating zynthian-webconf ..."
 cd $ZYNTHIAN_DIR/zynthian-webconf


### PR DESCRIPTION
Allows additional zynlibs to be added without need to touch zynthian-sys repository.
Implements feature zynthian/zynthian-issue-tracking#237.
Depends on corresponding PR in zynthian-ui repro: https://github.com/zynthian/zynthian-ui/pull/281.