### PR TITLE
Use documented and observed service name for RTP-MIDI

### DIFF
--- a/etc/avahi/services/zynthian-rtpmidi.service
+++ b/etc/avahi/services/zynthian-rtpmidi.service
@@ -3,7 +3,7 @@
 <service-group>
 <name replace-wildcards="yes">%h ZYNTHIAN RTPMIDI</name>
 <service>
-<type>_rtpmidi._udp</type>
+<type>_apple-midi._udp</type>
 <port>5004</port>
 </service>
 </service-group>


### PR DESCRIPTION
_apple-midi._udp is the documented [1] service name, and also observed
in existing hardware and software implementations. This makes Zynthian
actually visible to other RTP-MIDI implementations.

[1] https://developer.apple.com/library/archive/documentation/Audio/Conceptual/MIDINetworkDriverProtocol/MIDI/MIDI.html