### PR TITLE
Switch back to zynthian/mod-ui

### DIFF
--- a/scripts/recipes.update/update_modui.sh
+++ b/scripts/recipes.update/update_modui.sh
@@ -9,13 +9,14 @@ if [[ "$changed" -eq 1 ]]; then
 fi
 
 cd $ZYNTHIAN_SW_DIR/mod-ui
-git pull | grep -q -v 'Already up.to.date.' && changed=1
-if [[ "$changed" -eq 1 ]]; then
-	#pip3 install -r requirements.txt
-	cd utils
-	make -j 4
-	cd ..
-fi
+git remote remove origin
+git remote add origin https://github.com/zynthian/mod-ui.git
+git fetch origin zyn-mod-merge
+git checkout zyn-mod-merge
+git reset --hard origin/zyn-mod-merge
+
+cd utils
+make -j 4
 
 if [ ! -d "$ZYNTHIAN_SW_DIR/mod-ui/data" ]; then
 	mkdir "$ZYNTHIAN_SW_DIR/mod-ui/data"

--- a/scripts/recipes/install_mod-ui.sh
+++ b/scripts/recipes/install_mod-ui.sh
@@ -2,8 +2,8 @@
 
 # mod-ui
 cd $ZYNTHIAN_SW_DIR
-#git clone --recursive https://github.com/zynthian/mod-ui.git
-git clone --recursive --single-branch --branch zyn-mod-merge https://github.com/steveb/mod-ui.git
+rm -rf mod-ui
+git clone --recursive --single-branch --branch zyn-mod-merge https://github.com/zynthian/mod-ui.git
 cd mod-ui
 
 if [[ -n $MOD_UI_GITSHA ]]; then
@@ -11,12 +11,8 @@ if [[ -n $MOD_UI_GITSHA ]]; then
 	git checkout zynthian
 fi
 
-#pip3 install -r requirements.txt
-#pip3 install pyserial==2.7 pystache==0.5.4 aggdraw==1.3.7
 pip3 install pyserial==3.0 pystache==0.5.4 aggdraw==1.3.11
 pip3 install git+git://github.com/dlitz/pycrypto@master#egg=pycrypto
-#Pillow==6.2.2
-#tornado==4.3
 
 cd utils
 make


### PR DESCRIPTION
The current zyn-mod-merge branch is identical on zynthian/mod-ui and
steveb/mod-ui, this change switches back to zynthian, and also deletes the
mod-ui directory before the git clone to avoid issues with existing clones.