### PR TITLE
Install mod-ui cabsim-IR-loader

### DIFF
--- a/scripts/recipes/install_mod-cabsim-IR-loader.sh
+++ b/scripts/recipes/install_mod-cabsim-IR-loader.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+# cabsim-IR-loader.lv2
+cd $ZYNTHIAN_PLUGINS_SRC_DIR
+if [ -d "mod-cabsim-IR-loader" ]; then
+	rm -rf "mod-cabsim-IR-loader"
+fi
+
+git clone https://github.com/moddevices/mod-cabsim-IR-loader.git
+cd mod-cabsim-IR-loader/source
+make
+cp -r *.lv2 $ZYNTHIAN_PLUGINS_DIR/lv2/

--- a/scripts/setup_plugins_rbpi.sh
+++ b/scripts/setup_plugins_rbpi.sh
@@ -110,6 +110,7 @@ $ZYNTHIAN_RECIPE_DIR/install_surge_prebuilt.sh
 $ZYNTHIAN_RECIPE_DIR/install_alo.sh
 $ZYNTHIAN_RECIPE_DIR/install_VL1.sh
 $ZYNTHIAN_RECIPE_DIR/install_qmidiarp.sh
+$ZYNTHIAN_RECIPE_DIR/install_mod-cabsim-IR-loader.sh
 
 # X42 plugins
 #$ZYNTHIAN_RECIPE_DIR/install_fat1.sh


### PR DESCRIPTION
This is an LV2 plugin which allows arbitrary impulse responses to be loaded.

It is not obvious how other impulse response files are loaded though, currently
it is only showing forward-audio_AliceInBones.wav in the mod-ui plugin menu.