### PR TITLE
Add browsepy service for mod-ui

### DIFF
--- a/etc/systemd/browsepy.service
+++ b/etc/systemd/browsepy.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=browsepy
+
+[Service]
+Environment=HOME=/root
+Environment=BROWSEPY_HOST=0.0.0.0
+Environment=BROWSEPY_PORT=8081
+
+WorkingDirectory=#BROWSEPY_ROOT#
+ExecStart=#BROWSEPY_PATH#/browsepy --directory #BROWSEPY_ROOT# --upload #BROWSEPY_ROOT#
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+

--- a/etc/systemd/mod-ui.service
+++ b/etc/systemd/mod-ui.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=MOD-UI
 After=mod-host.service
+After=browsepy.service
 Requires=mod-host.service
+Requires=browsepy.service
 
 [Service]
 Environment=HOME=/root
@@ -14,6 +16,7 @@ Environment=MOD_LOG=0
 Environment=MOD_APP=0
 Environment=MOD_LIVE_ISO=0
 Environment=MOD_SYSTEM_OUTPUT=1
+Environment=MOD_USER_FILES_DIR=#BROWSEPY_ROOT#
 WorkingDirectory=#ZYNTHIAN_SW_DIR#/mod-ui
 ExecStart=#ZYNTHIAN_SW_DIR#/mod-ui/server.py
 Restart=always

--- a/scripts/recipes.update/update_modui.sh
+++ b/scripts/recipes.update/update_modui.sh
@@ -21,3 +21,7 @@ make -j 4
 if [ ! -d "$ZYNTHIAN_SW_DIR/mod-ui/data" ]; then
 	mkdir "$ZYNTHIAN_SW_DIR/mod-ui/data"
 fi
+
+if [ ! -d "$ZYNTHIAN_SW_DIR/browsepy" ]; then
+	$ZYNTHIAN_RECIPE_DIR/install_mod-browsepy.sh
+fi

--- a/scripts/recipes/install_mod-browsepy.sh
+++ b/scripts/recipes/install_mod-browsepy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# browsepy
+cd $ZYNTHIAN_SW_DIR
+rm -rf browsepy
+git clone https://github.com/moddevices/browsepy.git
+cd browsepy 
+
+pip3 install scandir backports.shutil-get-terminal-size
+pip3 install ./

--- a/scripts/setup_system_rbpi_raspbian_lite_buster.sh
+++ b/scripts/setup_system_rbpi_raspbian_lite_buster.sh
@@ -435,6 +435,9 @@ $ZYNTHIAN_RECIPE_DIR/install_mod-ui.sh
 #Install MOD-SDK
 #$ZYNTHIAN_RECIPE_DIR/install_mod-sdk.sh
 
+# Install browsepy
+$ZYNTHIAN_RECIPE_DIR/install_mod-browsepy.sh
+
 #------------------------------------------------
 # Install Plugins
 #------------------------------------------------

--- a/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
+++ b/scripts/setup_system_rbpi_raspbian_lite_stretch.sh
@@ -393,6 +393,9 @@ $ZYNTHIAN_RECIPE_DIR/install_mod-ui.sh
 #Install MOD-SDK
 $ZYNTHIAN_RECIPE_DIR/install_mod-sdk.sh
 
+# Install browsepy
+$ZYNTHIAN_RECIPE_DIR/install_mod-browsepy.sh
+
 #------------------------------------------------
 # Install Plugins
 #------------------------------------------------

--- a/scripts/update_zynthian_sys.sh
+++ b/scripts/update_zynthian_sys.sh
@@ -135,6 +135,9 @@ if [ -z "$ZYNTHIAN_HOSTSPOT_PASSWORD" ]; then
 	export ZYNTHIAN_HOSTSPOT_PASSWORD="raspberry"
 fi
 
+export BROWSEPY_PATH="/usr/local/bin"
+export BROWSEPY_ROOT="$ZYNTHIAN_MY_DATA_DIR/files/mod-ui"
+
 #Check for EPDF Hat
 /zynthian/zynthian-sys/scripts/epdf_detect.sh 
 ZYNTHIAN_EPDF_HAT=$?
@@ -157,6 +160,8 @@ ZYNTHIAN_CONFIG_DIR_ESC=${ZYNTHIAN_CONFIG_DIR//\//\\\/}
 ZYNTHIAN_SYS_DIR_ESC=${ZYNTHIAN_SYS_DIR//\//\\\/}
 ZYNTHIAN_UI_DIR_ESC=${ZYNTHIAN_UI_DIR//\//\\\/}
 ZYNTHIAN_SW_DIR_ESC=${ZYNTHIAN_SW_DIR//\//\\\/}
+BROWSEPY_ROOT_ESC=${BROWSEPY_ROOT//\//\\\/}
+BROWSEPY_PATH_ESC=${BROWSEPY_PATH//\//\\\/}
 
 JACKD_BIN_PATH_ESC=${JACKD_BIN_PATH//\//\\\/}
 JACKD_OPTIONS_ESC=${JACKD_OPTIONS//\//\\\/}
@@ -258,6 +263,14 @@ fi
 # Fix Pianoteq Presets Cache location
 if [ -d "$ZYNTHIAN_MY_DATA_DIR/pianoteq6" ]; then
 	mv "$ZYNTHIAN_MY_DATA_DIR/pianoteq6" $ZYNTHIAN_CONFIG_DIR
+fi
+# Set up browsepy directories
+if [ ! -d "$BROWSEPY_ROOT" ]; then
+     mkdir -p $BROWSEPY_ROOT
+fi
+# TODO create other directories and symlinks to existing file types in $ZYNTHIAN_MY_DATA_DIR
+if [ ! -d "$BROWSEPY_ROOT/Speaker Cabinets IRs" ]; then
+     mkdir -p "$BROWSEPY_ROOT/Speaker Cabinets IRs"
 fi
 
 # Setup Aeolus Config
@@ -481,6 +494,10 @@ sed -i -e "s/#ZYNTHIAN_SW_DIR#/$ZYNTHIAN_SW_DIR_ESC/g" /etc/systemd/system/mod-s
 # MOD-UI service
 sed -i -e "s/#LV2_PATH#/$LV2_PATH_ESC/g" /etc/systemd/system/mod-ui.service
 sed -i -e "s/#ZYNTHIAN_SW_DIR#/$ZYNTHIAN_SW_DIR_ESC/g" /etc/systemd/system/mod-ui.service
+sed -i -e "s/#BROWSEPY_ROOT#/$BROWSEPY_ROOT_ESC/g" /etc/systemd/system/mod-ui.service
+# browsepy service
+sed -i -e "s/#BROWSEPY_PATH#/$BROWSEPY_PATH_ESC/g" /etc/systemd/system/browsepy.service
+sed -i -e "s/#BROWSEPY_ROOT#/$BROWSEPY_ROOT_ESC/g" /etc/systemd/system/browsepy.service
 # VNCServcer service
 sed -i -e "s/#ZYNTHIAN_SYS_DIR#/$ZYNTHIAN_SYS_DIR_ESC/g" "/etc/systemd/system/vncserver@:1.service"
 # noVNC service


### PR DESCRIPTION
This is required for the new File Manager feature of mod-ui. browsepy is a
moddevices fork which is patched for a specific directory layout. This change
only adds the 'Speaker Cabinets IRs' directory of that layout to support the
new cabsim plugin.