### PR TITLE
Add riban lv2 plugins

### DIFF
--- a/scripts/recipes.update.buster/00_install_packages.sh
+++ b/scripts/recipes.update.buster/00_install_packages.sh
@@ -139,6 +139,12 @@ fi
 if [ ! -d "$ZYNTHIAN_PLUGINS_SRC_DIR/mod-cabsim-IR-loader" ]; then
 	$ZYNTHIAN_RECIPE_DIR/install_mod-cabsim-IR-loader.sh
 fi
+
+# 2021-03-31: Install riban LV2 plugins
+if [ ! -e $ZYNTHIAN_PLUGINS_DIR/lv2/riban ]; then
+	$ZYNTHIAN_RECIPE_DIR/install_riban_lv2.sh
+fi
+
 	
 # Install needed apt packages 
 if [ ! -z "$aptpkgs" ]; then

--- a/scripts/recipes.update.stretch/00_install_packages.sh
+++ b/scripts/recipes.update.stretch/00_install_packages.sh
@@ -89,3 +89,8 @@ if [ ! -e $ZYNTHIAN_PLUGINS_DIR/lv2/bg-arpeggiator.lv2 ]; then
 	$ZYNTHIAN_RECIPE_DIR/install_arpeggiator.sh
 fi
 
+# 2021-03-31: Install riban LV2 plugins
+if [ ! -e $ZYNTHIAN_PLUGINS_DIR/lv2/riban ]; then
+	$ZYNTHIAN_RECIPE_DIR/install_riban_lv2.sh
+fi
+

--- a/scripts/recipes.update.stretch/00_install_packages.sh
+++ b/scripts/recipes.update.stretch/00_install_packages.sh
@@ -88,9 +88,3 @@ systemctl enable zynthian-config-on-boot
 if [ ! -e $ZYNTHIAN_PLUGINS_DIR/lv2/bg-arpeggiator.lv2 ]; then
 	$ZYNTHIAN_RECIPE_DIR/install_arpeggiator.sh
 fi
-
-# 2021-03-31: Install riban LV2 plugins
-if [ ! -e $ZYNTHIAN_PLUGINS_DIR/lv2/riban ]; then
-	$ZYNTHIAN_RECIPE_DIR/install_riban_lv2.sh
-fi
-

--- a/scripts/recipes.update/update_riban_lv2.sh
+++ b/scripts/recipes.update/update_riban_lv2.sh
@@ -7,7 +7,7 @@ CURRENT=$(git rev-parse HEAD)
 
 if [ " $CURRENT " != " $STABLE " ]
 then
-	git checkout -f "$STABLE"
+	git checkout -fq "$STABLE"
 	for dir in */
 	do
 		cd $dir

--- a/scripts/recipes.update/update_riban_lv2.sh
+++ b/scripts/recipes.update/update_riban_lv2.sh
@@ -1,0 +1,21 @@
+ORIG_PWD=$(pwd)
+STABLE=2103
+STABLE=3b22aa935b03fbd92a61b9dc52919cd3bc12e8a5
+
+cd $ZYNTHIAN_PLUGINS_SRC_DIR/riban
+CURRENT=$(git rev-parse HEAD)
+
+if [ " $CURRENT " != " $STABLE " ]
+then
+	git checkout -f "$STABLE"
+	for dir in */
+	do
+		cd $dir
+		sed -i "s#^PREFIX.*=.*#PREFIX := $ZYNTHIAN_PLUGINS_DIR#" Makefile
+		sed -i "s#^DESTDIR.*=.*#DESTDIR := /lv2#" Makefile
+		make
+		make install
+		cd -
+	done
+fi
+cd $ORIG_PWD

--- a/scripts/recipes/install_riban_lv2.sh
+++ b/scripts/recipes/install_riban_lv2.sh
@@ -8,15 +8,4 @@ if [ -d riban ]; then
 fi
 
 git clone --recursive https://github.com/riban-bw/lv2.git riban
-cd riban
-
-for dir in */
-do
-	cd $dir
-	sed -i "s#^DESTDIR ?=#DESTDIR := $ZYNTHIAN_PLUGINS_DIR#" Makefile
-	make clean
-	make
-	make install
-	cd -
-done
-
+bash $ZYNTHIAN_SYS_DIR/scripts/recipes.update/update_riban_lv2.sh

--- a/scripts/recipes/install_riban_lv2.sh
+++ b/scripts/recipes/install_riban_lv2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# riban LV2 plugins
+cd $ZYNTHIAN_PLUGINS_SRC_DIR
+
+if [ -d riban ]; then
+	rm -rf riban
+fi
+
+git clone --recursive https://github.com/riban-bw/lv2.git riban
+cd riban
+
+for dir in */
+do
+	cd $dir
+	sed -i "s#^DESTDIR ?=#DESTDIR := $ZYNTHIAN_PLUGINS_DIR#" Makefile
+	make clean
+	make
+	make install
+	cd -
+done
+

--- a/scripts/recipes/install_riban_lv2.sh
+++ b/scripts/recipes/install_riban_lv2.sh
@@ -8,4 +8,14 @@ if [ -d riban ]; then
 fi
 
 git clone --recursive https://github.com/riban-bw/lv2.git riban
-bash $ZYNTHIAN_SYS_DIR/scripts/recipes.update/update_riban_lv2.sh
+
+cd riban
+for dir in */
+do
+	cd $dir
+	sed -i "s#^PREFIX.*=.*#PREFIX := $ZYNTHIAN_PLUGINS_DIR#" Makefile
+	sed -i "s#^DESTDIR.*=.*#DESTDIR := /lv2#" Makefile
+	make
+	make install
+	cd -
+done


### PR DESCRIPTION
I wrote a plugin to provide configurable chords for each note of the octave. To share this I created a new repository on GitHub to host my LV2 plugins. Just this one for now. I added install and update scripts. The updated script looks for a specific version based on the git commit ID hence will only update under Zynthian change control.

I found Zynthian fails to find the plugin after installation until a reboot. Scanning for plugins allows it to be seen in the list but attempts to add it to a layer trigger an error:

```
Mar 31 22:12:05 zynthian startx[487]: ERROR:zynthian_gui.zyncoder_read: 'Plugin not found: urn:riban.multi_chord'
Mar 31 22:12:05 zynthian startx[487]: Traceback (most recent call last):
Mar 31 22:12:05 zynthian startx[487]:   File "./zynthian_gui.py", line 1241, in zyncoder_read
Mar 31 22:12:05 zynthian startx[487]:     self.zynswitches()
Mar 31 22:12:05 zynthian startx[487]:   File "./zynthian_gui.py", line 940, in zynswitches
Mar 31 22:12:05 zynthian startx[487]:     self.zynswitch_short(i)
Mar 31 22:12:05 zynthian startx[487]:   File "./zynthian_gui.py", line 1135, in zynswitch_short
Mar 31 22:12:05 zynthian startx[487]:     self.screens[self.modal_screen].switch_select('S')
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngui/zynthian_gui_selector.py", line 251, in switch_select
Mar 31 22:12:05 zynthian startx[487]:     self.click_listbox(None, t)
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngui/zynthian_gui_selector.py", line 247, in click_listbox
Mar 31 22:12:05 zynthian startx[487]:     self.select_action(self.index, t)
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngui/zynthian_gui_midi_chan.py", line 115, in select_action
Mar 31 22:12:05 zynthian startx[487]:     self.zyngui.screens['layer'].add_layer_midich(selchan)
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngui/zynthian_gui_layer.py", line 301, in add_layer_midich
Mar 31 22:12:05 zynthian startx[487]:     zyngine = self.zyngui.screens['engine'].start_engine(self.add_layer_eng)
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngui/zynthian_gui_engine.py", line 178, in start_engine
Mar 31 22:12:05 zynthian startx[487]:     self.zyngines[eng]=zynthian_engine_class(info[0], info[2], self.zyngui)
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngine/zynthian_engine_jalv.py", line 201, in __init__
Mar 31 22:12:05 zynthian startx[487]:     self.lv2_zctrl_dict = self.get_lv2_controllers_dict()
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngine/zynthian_engine_jalv.py", line 305, in get_lv2_controllers_dict
Mar 31 22:12:05 zynthian startx[487]:     for i, info in zynthian_lv2.get_plugin_ports(self.plugin_url).items():
Mar 31 22:12:05 zynthian startx[487]:   File "/home/pi/zynthian-ui/zyngine/zynthian_lv2.py", line 401, in get_plugin_ports
Mar 31 22:12:05 zynthian startx[487]:     plugin = plugins[plugin_url]
Mar 31 22:12:05 zynthian startx[487]:   File "/usr/local/lib/python3.7/dist-packages/lilv.py", line 981, in __getitem__
Mar 31 22:12:05 zynthian startx[487]:     raise KeyError("Plugin not found: " + str(key))
```

I wonder whether this is related to my installation scripts or an existing bug within Zynthian?

I have tested the plugin and it seems to behave as expected.