### PR TITLE
Added installation script for simsam.lv2.

### DIFF
--- a/scripts/recipes/install_simsam.sh
+++ b/scripts/recipes/install_simsam.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ${ZYNTHIAN_PLUGINS_SRC_DIR}
-git clone https://gitlab.com/edwillys/simsam.git
-cd simsam
+git clone https://gitlab.com/edwillys/simsam.git simsam.lv2
+cd simsam.lv2
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..

--- a/scripts/recipes/install_simsam.sh
+++ b/scripts/recipes/install_simsam.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+cd ${ZYNTHIAN_PLUGINS_SRC_DIR}
+git clone https://gitlab.com/edwillys/simsam.git
+cd simsam
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
+mkdir ${ZYNTHIAN_PLUGINS_DIR}/lv2/simsam.lv2
+cp simsam.so ${ZYNTHIAN_PLUGINS_DIR}/lv2/simsam.lv2
+cd ../bundles/simsam.lv2
+cp -R * ${ZYNTHIAN_PLUGINS_DIR}/lv2/simsam.lv2
+cd ${ZYNTHIAN_PLUGINS_DIR}/lv2/simsam.lv2/sfz
+git clone https://gitlab.com/edwillys/salamandergrandpiano.git
+git clone https://gitlab.com/edwillys/francisbaconpiano.git
+git clone https://gitlab.com/edwillys/SteinwaySonsModelB.git


### PR DESCRIPTION
Hi,

I added an installation script for `simsam.lv2` ([https://gitlab.com/edwillys/simsam](https://gitlab.com/edwillys/simsam)). This script installs also the piano samples as SFZ from edwillys. There are some useful Python scripts in the folder `${ZYNTHIAN_PLUGINS_SRC_DIR}/simsam/tools` for generating/manipulating own SFZ instruments. Uploading of files has currently to be done by ssh into the folder `${ZYNTHIAN_PLUGINS_DIR}/lv2/simsam.lv2/sfz`.