### PR TITLE
mod-ui, install zyn-mod-merge-20230514

### DIFF
--- a/scripts/recipes/install_mod-ui.sh
+++ b/scripts/recipes/install_mod-ui.sh
@@ -3,7 +3,7 @@
 # mod-ui
 cd $ZYNTHIAN_SW_DIR
 rm -rf mod-ui
-git clone --recursive --single-branch --branch zyn-mod-merge-next https://github.com/zynthian/mod-ui.git
+git clone --recursive --single-branch --branch zyn-mod-merge-20230514 https://github.com/zynthian/mod-ui.git
 cd mod-ui
 
 if [[ -n $MOD_UI_GITSHA ]]; then


### PR DESCRIPTION
This branch has rebased on the current state of upstream mod-ui, with zynthian patches applied.

I have noticed no regressions and switching to this fixed one issue I was having with websocket connection handling which stopped real time updates from showing in the mod-ui browser app for some plugins.