### PR TITLE
install_ripplerx.sh: -fPIC patch no longer necessary

### DIFF
--- a/scripts/recipes/install_ripplerx.sh
+++ b/scripts/recipes/install_ripplerx.sh
@@ -10,10 +10,6 @@ fi
 git clone --recurse-submodules https://github.com/tiagolr/ripplerx.git
 cd ripplerx
 
-# Add "-fPIC" option to CMake config file
-#sed -i "s#set(CMAKE_CXX_STANDARD 17)#set(CMAKE_CXX_STANDARD 17)\nset(CMAKE_CXX_FLAGS \"-fPIC\")#" CMakeLists.txt
-sed -i "s#set(CMAKE_CXX_STANDARD 17)#set(CMAKE_CXX_STANDARD 17)\nset(CMAKE_POSITION_INDEPENDENT_CODE ON)#" CMakeLists.txt
-
 # Build
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -S . -B ./build
 cmake --build ./build --config Release


### PR DESCRIPTION
Upstream RipplerX now includes this line by default: https://github.com/tiagolr/ripplerx/blob/ca53607e7d96b62974002b6dd0c437f485390e0a/CMakeLists.txt#L5

Although there's no harm in inserting the line a second time, even after updating RipplerX to newer versions.

This is a companion pull request to https://github.com/zynthian/zynthian-data/pull/26 which updates the custom dsp.ttl for RipplerX v1.5.18.