### PR TITLE
update_zynthian_sys: drive X11 rotation from DISPLAY_ROTATION (add 90…

### DIFF
--- a/scripts/update_zynthian_sys.sh
+++ b/scripts/update_zynthian_sys.sh
@@ -429,17 +429,29 @@ if [ -f "/etc/X11/xorg.conf.d/99-fbdev.conf" ]; then
 	rm -f "/etc/X11/xorg.conf.d/99-fbdev.conf"
 fi
 
-# Autodetect display rotation and configure X11 accordingly
-if [[ ( "$DISPLAY_CONFIG" == *"display_lcd_rotate=2"* ) ]]; then
-	echo "Configuring X11 inverted display ..."
-	cat > "/etc/X11/xorg.conf.d/69-display_inverted.conf" << EOF
+# Configure X11 display rotation from DISPLAY_ROTATION.
+# DISPLAY_ROTATION drives both touch rotation (in zynthian-ui's multitouch
+# driver) and, here, the X11 screen rotation, so a single setting rotates
+# both layers together. Legacy displays that only set display_lcd_rotate=2
+# in DISPLAY_CONFIG still get an inverted screen via the fallback below.
+rm -f /etc/X11/xorg.conf.d/69-display_*.conf
+X11_ROTATE=""
+case "$DISPLAY_ROTATION" in
+	Right) X11_ROTATE="right" ;;
+	Left) X11_ROTATE="left" ;;
+	Inverted) X11_ROTATE="inverted" ;;
+esac
+if [[ -z "$X11_ROTATE" && "$DISPLAY_CONFIG" == *"display_lcd_rotate=2"* ]]; then
+	X11_ROTATE="inverted"
+fi
+if [[ -n "$X11_ROTATE" ]]; then
+	echo "Configuring X11 display rotation: $X11_ROTATE ..."
+	cat > "/etc/X11/xorg.conf.d/69-display_rotation.conf" << EOF
 Section "Monitor"
   Identifier "DSI-1"
-  Option "Rotate" "inverted"
+  Option "Rotate" "$X11_ROTATE"
 EndSection
 EOF
-else
-	rm -f /etc/X11/xorg.conf.d/69-display_*.conf
 fi
 
 if [ "$ZYNTHIAN_UI_ENABLE_CURSOR" == "1" ]; then


### PR DESCRIPTION
# update_zynthian_sys: drive X11 display rotation from DISPLAY_ROTATION (add 90°/270°)

**Base:** `zynthian/zynthian-sys:vangelis`
**Part of a set:** pairs with a `zynthian-webconf` PR (adds the Touch Display 2 option + Right/Left in the UI) and builds on `zynthian/zynthian-ui#580` (touch-side rotation). Links below.

## Problem

`update_zynthian_sys.sh` generates the X11 monitor file that rotates the screen, but only for the 180° case: it writes `Option "Rotate" "inverted"` when `DISPLAY_CONFIG` contains the `display_lcd_rotate=2` sentinel. There is no path for 90°/270°, so a portrait-native DSI panel (e.g. the Raspberry Pi Touch Display 2) cannot be brought up in landscape through configuration — the picture stays portrait.

## Change

Replace the inverted-only block with a small `case` on `DISPLAY_ROTATION`:

- `Right` → `Option "Rotate" "right"` (90°)
- `Left` → `Option "Rotate" "left"` (270°)
- `Inverted` → `Option "Rotate" "inverted"` (180°)

written to a single `69-display_rotation.conf` (the existing `69-display_*.conf` cleanup glob still covers it, so no stale files).

### Design note (worth a maintainer opinion)

This keys the X11 screen rotation off **`DISPLAY_ROTATION`**, the same variable `zynthian-ui` already uses for touch rotation (see #580). The intent is that one setting rotates both layers together, which is what a user mounting a panel sideways expects. This does widen `DISPLAY_ROTATION` from touch-only to touch + display; an alternative would be a `DISPLAY_CONFIG` sentinel mirroring `display_lcd_rotate=2`. Happy to switch to the sentinel approach if you'd prefer to keep the variable touch-scoped — it's a localized change to this block.

### Backward compatibility

The legacy `display_lcd_rotate=2` sentinel is kept as a fallback: if `DISPLAY_ROTATION` is unset/`None` but that sentinel is present, the script still produces an inverted screen. So existing inverted displays (including the V5 legacy fixup earlier in this script) are unaffected. Verified behaviour:

| `DISPLAY_ROTATION` | `DISPLAY_CONFIG` has sentinel | result |
|---|---|---|
| `None` | no | no rotation file (unchanged) |
| `Right` | no | `Rotate "right"` (new) |
| `Left` | no | `Rotate "left"` (new) |
| `Inverted` | yes | `Rotate "inverted"` (unchanged) |
| `None` | yes (legacy) | `Rotate "inverted"` (preserved) |

## Testing

Verified on a Raspberry Pi 5 + Raspberry Pi Touch Display 2 (7″): with `DISPLAY_ROTATION=Right` the panel comes up in landscape and, combined with #580, touch tracks correctly across the full screen.

## Related

- zynthian-ui: zynthian/zynthian-ui#580 (touch-side 90°/270° rotation)
- zynthian-webconf: github.com/zynthian/zynthian-webconf/pull/200 (Touch Display 2 display option + Right/Left in the dropdown)

…/270)