### PR TITLE
Ft spotifyd

### DIFF
--- a/config/engine_config.json
+++ b/config/engine_config.json
@@ -7394,6 +7394,21 @@
 "COMPLEX": 1,
 "EDIT": 0
 },
+"SP": {
+"ID": "9e5de72ce1",
+"NAME": "SpotifyConnect",
+"TITLE": "Spotify Connect",
+"TYPE": "Audio Generator",
+"CAT": "Other",
+"ENABLED": true,
+"INDEX": 12,
+"URL": "",
+"UI": "",
+"DESCR": "Spotify connect client.",
+"QUALITY": 3,
+"COMPLEX": 1,
+"EDIT": 0
+},
 "JV/Invada Compressor (mono)": {
 "ID": "b6cc69e6a9",
 "NAME": "Invada Compressor (mono)",

--- a/config/engine_config.json
+++ b/config/engine_config.json
@@ -7404,7 +7404,7 @@
 "INDEX": 12,
 "URL": "",
 "UI": "",
-"DESCR": "Spotify connect client.",
+"DESCR": "Spotify connect client. Needs Spotify Premium account. Use at own risk, see spotifyd.",
 "QUALITY": 3,
 "COMPLEX": 1,
 "EDIT": 0

--- a/scripts/recipes/install_spotifyd.sh
+++ b/scripts/recipes/install_spotifyd.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd $ZYNTHIAN_PLUGINS_SRC_DIR
+# sha256:723872217c92ce9f10692caf4e96ddd8791b373ebd6dfb2eb42152a9cb56eda2
+wget https://github.com/Spotifyd/spotifyd/releases/download/v0.4.2/spotifyd-linux-aarch64-full.tar.gz
+
+tar xzf spotifyd-linux-aarch64-full.tar.gz
+rm spotifyd-linux-aarch64-full.tar.gz
+
+mv spotifyd /usr/local/bin/
+chmod +x /usr/local/bin/spotifyd
+
+sudo apt install libssl1.1
+
+
+


### PR DESCRIPTION
Adds an Audio Generator Chain to serve as Spotify connect. Useful for studying passages (autotuning entire songs haha), making loops, or just listening.

Uses spotifyd under the hood, which needs a premium subscription.

Works only in tandem with the PR at zynthian-ui https://github.com/zynthian/zynthian-ui/pull/581

See https://discourse.zynthian.org/t/spotify-connect-chain/13004/6



